### PR TITLE
Fix building using Qt < 5.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,11 @@ include(FindIntl)
 
 option(USE_QT6 "Use Qt6 instead of Qt5" ON)
 if (${USE_QT6})
-    find_package(Qt6 REQUIRED COMPONENTS Core Widgets Concurrent)
+    find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Concurrent)
 else()
-    find_package(Qt5 REQUIRED COMPONENTS Core Widgets Concurrent)
+    find_package(QT NAMES Qt5 REQUIRED COMPONENTS Core)
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Concurrent)
 endif()
 
 set(sources
@@ -127,7 +129,8 @@ if (${USE_NLS})
     endif()
 endif()
 
-target_link_libraries(${libTarget} PRIVATE ${Intl_LIBRARIES} Qt::Core Qt::Widgets Qt::Concurrent)
+target_link_libraries(${libTarget} PRIVATE ${Intl_LIBRARIES} Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Concurrent)
 
 set(configFileName ${libName}-config.cmake)
 write_basic_package_version_file(${libName}-config-version.cmake COMPATIBILITY SameMajorVersion)


### PR DESCRIPTION
Building using Qt 5.9.7 (e.g. RHEL/CentOS 7) fails like this:

```
CMake Error at CMakeLists.txt:103 (add_library):
  Target "ampache_browser" links to target "Qt::Core" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?
CMake Error at CMakeLists.txt:103 (add_library):
  Target "ampache_browser" links to target "Qt::Widgets" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
CMake Error at CMakeLists.txt:103 (add_library):
  Target "ampache_browser" links to target "Qt::Concurrent" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
```

Patch inspired by https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html#supporting-older-qt-5-versions